### PR TITLE
fix(doc): updated readme.md file with correct WDIO installation page URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can install wdio-novus-visual-regression-service via NPM as usual:
 $ npm install wdio-novus-visual-regression-service --save-dev
 ```
 
-Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/guide/getstarted/install.html)
+Instructions on how to install `WebdriverIO` can be found [here.](https://webdriver.io/docs/gettingstarted)
 
 ## Configuration
 Setup wdio-novus-visual-regression-service by adding `novus-visual-regression` to the service section of your WebdriverIO config and define your desired comparison strategy in the service options.


### PR DESCRIPTION
updated readme.md file with correct WDIO installation page URL. that is https://webdriver.io/docs/gettingstarted.

<img width="710" alt="Screen Shot 2022-12-16 at 1 55 47 PM" src="https://user-images.githubusercontent.com/8421048/208169337-19a68d9c-3e0c-4b6a-95c9-318ad36d6901.png">
